### PR TITLE
Fix scripts

### DIFF
--- a/workspace/scripts/runtime/turn_off_all_leds.sh
+++ b/workspace/scripts/runtime/turn_off_all_leds.sh
@@ -5,6 +5,7 @@ export FRONT_LED_BRIGHTNESS_PATH="$BASE_LED_PATH/max_scale_f1f2"
 export BACK_LED_BRIGHTNESS_PATH="$BASE_LED_PATH/max_scale_lr"
 export SCRIPT_NAME=$(basename "$0")
 
-chmod a-w $BASE_LED_PATH/*
+chmod a+w $BASE_LED_PATH/*
 echo "[`date '+%Y-%m-%d %H:%M:%S'`][$SCRIPT_NAME]: Turning off all LEDs"
 echo 0 | tee $TOP_BRIGHTNESS_PATH $FRONT_LED_BRIGHTNESS_PATH $BACK_LED_BRIGHTNESS_PATH
+chmod a-w $BASE_LED_PATH/*

--- a/workspace/scripts/runtime/turn_off_all_leds.sh
+++ b/workspace/scripts/runtime/turn_off_all_leds.sh
@@ -8,4 +8,3 @@ export SCRIPT_NAME=$(basename "$0")
 chmod a+w $BASE_LED_PATH/*
 echo "[`date '+%Y-%m-%d %H:%M:%S'`][$SCRIPT_NAME]: Turning off all LEDs"
 echo 0 | tee $TOP_BRIGHTNESS_PATH $FRONT_LED_BRIGHTNESS_PATH $BACK_LED_BRIGHTNESS_PATH
-chmod a-w $BASE_LED_PATH/*

--- a/workspace/scripts/runtime/turn_on_all_leds.sh
+++ b/workspace/scripts/runtime/turn_on_all_leds.sh
@@ -8,4 +8,3 @@ export SCRIPT_NAME=$(basename "$0")
 chmod a+w $BASE_LED_PATH/*
 echo "[`date '+%Y-%m-%d %H:%M:%S'`][$SCRIPT_NAME]: Turning on all LEDs"
 echo 200 | tee $TOP_BRIGHTNESS_PATH $FRONT_LED_BRIGHTNESS_PATH $BACK_LED_BRIGHTNESS_PATH
-chmod a-w $BASE_LED_PATH/*

--- a/workspace/scripts/runtime/turn_on_all_leds.sh
+++ b/workspace/scripts/runtime/turn_on_all_leds.sh
@@ -8,3 +8,4 @@ export SCRIPT_NAME=$(basename "$0")
 chmod a+w $BASE_LED_PATH/*
 echo "[`date '+%Y-%m-%d %H:%M:%S'`][$SCRIPT_NAME]: Turning on all LEDs"
 echo 200 | tee $TOP_BRIGHTNESS_PATH $FRONT_LED_BRIGHTNESS_PATH $BACK_LED_BRIGHTNESS_PATH
+chmod a-w $BASE_LED_PATH/*

--- a/workspace/scripts/runtime/uninstall.sh
+++ b/workspace/scripts/runtime/uninstall.sh
@@ -9,5 +9,5 @@ echo "[`date '+%Y-%m-%d %H:%M:%S'`][$SCRIPT_NAME]: Removing all led_controller f
 rm /etc/rc.d/*led-settings-daemon
 rm /etc/init.d/led-settings-daemon
 rm -rf $SERVICE_PATH
-
+chmod a+w $BASE_LED_PATH/*
 echo "[`date '+%Y-%m-%d %H:%M:%S'`][$SCRIPT_NAME]: exiting ..."


### PR DESCRIPTION
Looks like there was an issue in the uninstall script where I wasn't unlocking the LED path after I uninstalled. This prevents the LEDs from returning to normal operation afterwards. 

My turn off script also didn't check for permissions before running which would cause it to not work under certain scenarios.